### PR TITLE
fix: shellcheck requires docker to run

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -29,6 +29,7 @@ packages:
     - nano
     - pre-commit
     - pnpm
+    - shellcheck
     - starship
     - tflint
     - tldr
@@ -45,6 +46,7 @@ packages:
     - 1password
     - 1password-cli
     - alfred
+    - docker
     - flux
     - font-caskaydia-cove-nerd-font
     - google-chrome


### PR DESCRIPTION
... specifically in pre-existing repos with pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `shellcheck` to the list of available brew packages.
	- Introduced `docker` as a new cask application. 

These enhancements improve the package management experience by providing users with additional tools for installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->