### PR TITLE
feat: aliasing within AWS CLI

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -8,6 +8,7 @@ packages:
     - turbot/tap
     - warrensbox/tap
     brews:
+    - asciinema
     - antigen
     - awscli
     # - atuin
@@ -32,6 +33,7 @@ packages:
     - nano
     - pre-commit
     - pnpm
+    - scc
     - shellcheck
     - starship
     - tflint
@@ -57,6 +59,7 @@ packages:
     - google-chrome
     - iterm2
     - jordanbaird-ice
+    - privileges
     - rectangle
     - remember-the-milk
     - sublime-text

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -49,8 +49,9 @@ Workspace/Scratch/*
 Workspace/Stubs/*
 Workspace/*
 
-.aws/**
+.aws/*
 !.aws/config
+!.aws/cli
 .docker
 .flowpipe
 .granted/**

--- a/dot_aws/cli/alias
+++ b/dot_aws/cli/alias
@@ -1,0 +1,7 @@
+# Aliasing within the AWS CLI
+#
+# See: https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-alias.html for more information about cli aliases.
+# See: https://github.com/dannysteenman/aws-toolbox for potential examples
+
+[toplevel]
+whoami = sts get-caller-identity


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new brew package: `asciinema`.
	- Introduced new cask: `privileges`.
	- Added CLI alias `whoami` for retrieving AWS identity information.

- **Bug Fixes**
	- Updated ignore patterns in `.chezmoiignore` for more precise file tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->