### PR TITLE
fix: fpath inconsistency post-migration to workbrew

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -6,7 +6,8 @@ export PAGER="less"
 export GOBIN="$(go env GOPATH)/bin"
 export PATH="$GOBIN:$PATH"
 
-export FPATH="/usr/share/zsh/site-functions:/usr/share/zsh/5.9/functions:$FPATH"
+ZSH_VERSION=$(zsh --version | cut -d' ' -f2 | cut -d'.' -f1,2)
+export FPATH="/usr/share/zsh/site-functions:/usr/share/zsh/$ZSH_VERSION/functions:$FPATH"
 
 export NVM_AUTO_USE=true
 export SSH_AUTH_SOCK="$HOME/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock"

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -6,10 +6,13 @@ export PAGER="less"
 export GOBIN="$(go env GOPATH)/bin"
 export PATH="$GOBIN:$PATH"
 
+export FPATH=":/usr/share/zsh/site-functions:/usr/share/zsh/5.9/functions:$FPATH"
+
 export NVM_AUTO_USE=true
 export SSH_AUTH_SOCK="$HOME/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock"
 export TF_PRODUCT="terraform"
 export ZOXIDE_CMD_OVERRIDE="cd"
+
 
 source $HOMEBREW_PREFIX/share/antigen/antigen.zsh
 

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -6,13 +6,12 @@ export PAGER="less"
 export GOBIN="$(go env GOPATH)/bin"
 export PATH="$GOBIN:$PATH"
 
-export FPATH=":/usr/share/zsh/site-functions:/usr/share/zsh/5.9/functions:$FPATH"
+export FPATH="/usr/share/zsh/site-functions:/usr/share/zsh/5.9/functions:$FPATH"
 
 export NVM_AUTO_USE=true
 export SSH_AUTH_SOCK="$HOME/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock"
 export TF_PRODUCT="terraform"
 export ZOXIDE_CMD_OVERRIDE="cd"
-
 
 source $HOMEBREW_PREFIX/share/antigen/antigen.zsh
 


### PR DESCRIPTION
Signed up and installed Workbrew, which intercepts Homebrew to provide a managed experience. After installation everything worked except the terminal within VS Code; this fix patches or resolves the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new environment variable `ZSH_VERSION` to capture the Zsh version.
	- Enhanced `FPATH` to include paths for Zsh function directories based on the specific version.

- **Style**
	- Minor formatting adjustments made for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->