### PR TITLE
chore: support shift of goreleaser to brew cask

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -27,7 +27,6 @@ packages:
     - git
     - go
     - golangci-lint
-    - goreleaser/tap/goreleaser
     - httpie
     - jq
     - kaos/shell/bats-assert
@@ -64,6 +63,7 @@ packages:
     - ghostty
     - github
     - google-chrome
+    - goreleaser
     - iterm2
     - jordanbaird-ice
     - obsidian


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the installation method for Goreleaser, switching from a brew formula to a cask package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->